### PR TITLE
Specify scope separator in Oauth provider

### DIFF
--- a/src/Oauth2Provider.php
+++ b/src/Oauth2Provider.php
@@ -8,5 +8,8 @@ use League\OAuth2\Client\Provider\GenericProvider;
 
 class Oauth2Provider extends GenericProvider
 {
-
+    protected function getScopeSeparator()
+    {
+        return ' ';
+    }
 }

--- a/src/OauthCredentialManager.php
+++ b/src/OauthCredentialManager.php
@@ -55,7 +55,7 @@ class OauthCredentialManager
 
     public function getAuthorizationUrl()
     {
-        $redirectUrl = $this->oauthProvider->getAuthorizationUrl(['scope' => implode(' ', config('xero.oauth.scopes'))]);
+        $redirectUrl = $this->oauthProvider->getAuthorizationUrl(['scope' => config('xero.oauth.scopes')]);
         $this->session->put($this->cacheKey, $this->oauthProvider->getState());
 
         return $redirectUrl;


### PR DESCRIPTION
Removes the need to manually `implode` the scopes when getting the
authorization URL.