### PR TITLE
Throw exception if unable to write token to file

### DIFF
--- a/src/Oauth2CredentialManagers/FileStore.php
+++ b/src/Oauth2CredentialManagers/FileStore.php
@@ -91,13 +91,17 @@ class FileStore implements OauthCredentialManager
 
     public function store(AccessTokenInterface $token, string $tenantId = null): void
     {
-        $this->files->put($this->filePath, json_encode([
+        $ret = $this->files->put($this->filePath, json_encode([
             'token'         => $token->getToken(),
             'refresh_token' => $token->getRefreshToken(),
             'id_token'      => $token->getValues()['id_token'],
             'expires'       => $token->getExpires(),
             'tenant_id'     => $tenantId ?? $this->getTenantId()
         ]));
+        
+        if ($ret === false) {
+            throw new \Exception("Failed to write to file: {$this->filePath}");
+        }
     }
 
     public function getUser(): ?array


### PR DESCRIPTION
Had an instance where the file permissions were not allowing token file to be updated, it silently failed and retained old token,  which was causing grant errors.