### PR TITLE
Multi-Tenant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `laravel-xero-oauth2` will be documented in this file
 
+## v4.0.0 Release
+- Support multiple tenants on one connection #71
+
+> **Note**
+> Unless you are using a custom OauthCredentialStore then this should be an in-place update, however you may be required to
+> wipe and re-enable your credential storage.
+
+
 ## v3.0.0 Release
 - Change FileStore to use FilesystemManager with disk configuration #67
 - Drop Laravel 5 support

--- a/src/Oauth2CredentialManagers/CacheStore.php
+++ b/src/Oauth2CredentialManagers/CacheStore.php
@@ -40,9 +40,18 @@ class CacheStore implements OauthCredentialManager
         return $this->data('refresh_token');
     }
 
-    public function getTenantId(): string
+    public function getTenants(): ?array
     {
-        return $this->data('tenant_id');
+        return $this->data('tenants');
+    } 
+
+    public function getTenantId(int $tenant =0): string
+    {
+        if(!isset($this->data('tenants')[$tenant]))
+        {
+            throw new \Exception("No such tenant exists");
+        }
+        return $this->data('tenants')[$tenant]['Id'];
     }
 
     public function getExpires(): int
@@ -88,14 +97,14 @@ class CacheStore implements OauthCredentialManager
         $this->store($newAccessToken);
     }
 
-    public function store(AccessTokenInterface $token, string $tenantId = null): void
+    public function store(AccessTokenInterface $token, array $tenants = null): void
     {
         $this->cache->forever($this->cacheKey, [
             'token'         => $token->getToken(),
             'refresh_token' => $token->getRefreshToken(),
             'id_token'      => $token->getValues()['id_token'],
             'expires'       => $token->getExpires(),
-            'tenant_id'     => $tenantId ?? $this->getTenantId()
+            'tenants'       => $tenants ?? $this->getTenants()
         ]);
     }
 

--- a/src/Oauth2CredentialManagers/FileStore.php
+++ b/src/Oauth2CredentialManagers/FileStore.php
@@ -42,9 +42,18 @@ class FileStore implements OauthCredentialManager
         return $this->data('refresh_token');
     }
 
-    public function getTenantId(): string
+    public function getTenants(): ?array
     {
-        return $this->data('tenant_id');
+        return $this->data('tenants');
+    } 
+
+    public function getTenantId(int $tenant =0): string
+    {
+        if(!isset($this->data('tenants')[$tenant]))
+        {
+            throw new \Exception("No such tenant exists");
+        }
+        return $this->data('tenants')[$tenant]['Id'];
     }
 
     public function getExpires(): int
@@ -90,14 +99,14 @@ class FileStore implements OauthCredentialManager
         $this->store($newAccessToken);
     }
 
-    public function store(AccessTokenInterface $token, string $tenantId = null): void
+    public function store(AccessTokenInterface $token, array $tenants = null): void
     {
         $ret = $this->disk->put($this->filePath, json_encode([
             'token'         => $token->getToken(),
             'refresh_token' => $token->getRefreshToken(),
             'id_token'      => $token->getValues()['id_token'],
             'expires'       => $token->getExpires(),
-            'tenant_id'     => $tenantId ?? $this->getTenantId()
+            'tenants'       => $tenants ?? $this->getTenants()
         ]), 'private');
 
         if ($ret === false) {

--- a/src/OauthCredentialManager.php
+++ b/src/OauthCredentialManager.php
@@ -22,9 +22,14 @@ interface OauthCredentialManager {
     public function getAuthorizationUrl(): string;
 
     /**
+     * Get all tenants available
+    **/
+    public function getTenants(): ?array;
+
+    /**
      * Get the current tenant ID
      */
-    public function getTenantId(): string;
+    public function getTenantId(int $tenant =0): string;
 
     /**
      * Get the time the current access token expires (unix timestamp)
@@ -59,13 +64,13 @@ interface OauthCredentialManager {
      *   'refresh_token' => $token->getRefreshToken(),
      *   'id_token'      => $token->getValues()['id_token'],
      *   'expires'       => $token->getExpires(),
-     *   'tenant_id'     => $tenantId ?? $this->getTenantId(),
+     *   'tenants'       => $tenants ?? $this->getTenants(),
      * ]
      *
      * @param AccessTokenInterface $token
-     * @param string|null          $tenantId
+     * @param Array|null          $tenants
      */
-    public function store(AccessTokenInterface $token, string $tenantId = null): void;
+    public function store(AccessTokenInterface $token, array $tenants = null): void;
 
     /**
      * Get the current authenticated users details according to the id token
@@ -87,7 +92,7 @@ interface OauthCredentialManager {
      *   'refresh_token' => 'string',
      *   'id_token'      => 'string',
      *   'expires'       => 000000,
-     *   'tenant_id'     => 'string',
+     *   'tenants'     => 'array',
      * ]
      */
     public function getData(): array;


### PR DESCRIPTION
Adds Multi-Tenant storage

- getTenantID() extended to accept [index] key parameter, defaults to 0
- getTenants() provides currently connected tenants 
- store() modified to accept 'tenants' parameter, replacing previous 'tenantId' parameter
- OauthCredentialManger interface modified to suit above changes

Will break any custom UserStorageProviders due to changes in the OauthCredentialManager interface, resolution would be to modify custom providers to match interface.