### PR TITLE
Handle multiple tenants in XeroAuthorized

### DIFF
--- a/src/Events/XeroAuthorized.php
+++ b/src/Events/XeroAuthorized.php
@@ -18,6 +18,6 @@ class XeroAuthorized
         $this->refresh_token = $data['refresh_token'];
         $this->id_token      = $data['id_token'];
         $this->expires       = $data['expires'];
-        $this->tenant_id     = $data['tenant_id'];
+        $this->tenant_id     = $data['tenant_id'] ?? $data['tenants'][0]['Id'];
     }
 }

--- a/src/Events/XeroAuthorized.php
+++ b/src/Events/XeroAuthorized.php
@@ -18,6 +18,6 @@ class XeroAuthorized
         $this->refresh_token = $data['refresh_token'];
         $this->id_token      = $data['id_token'];
         $this->expires       = $data['expires'];
-        $this->tenant_id     = $data['tenant_id'] ?? $data['tenants'][0]['Id'];
+        $this->tenants       = $data['tenants'];
     }
 }


### PR DESCRIPTION
When I was connecting my app using this library I hit an issue where the oauth credentials were throwing an error: `Undefined array key "tenant_id"` , because the structure from `$oauth->getData()` had my tenants as an array, as opposed to the single tenant_id expected:

```
dd( $oauth->getData() );

// results in 

[
  "token" => "asdasdasdasdasdasd"
  "refresh_token" => null
  "id_token" => "asdasdasdasdasdasdasdaasd"
  "expires" => 1657593567
  "tenants" => [
    0 => [
      "Id" => "asdasdasd-asdasd-asdasd-asdasd-asdasdasda"
      "Name" => "Demo Company (AU)"
    ]
  ]
]
```

I'm not sure if this is a permanent API change or if the response changes depending on your Xero account settings or what, but this change allows for my integration to proceed without breaking anything else, so I thought I might as well push it!