### PR TITLE
feat: Modify Auth Callback Controller to support Xero errors

### DIFF
--- a/src/Exceptions/OAuthException.php
+++ b/src/Exceptions/OAuthException.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Webfox\Xero\Exceptions;
+
+use Exception;
+use Throwable;
+
+class OAuthException extends Exception
+{
+    public function __construct($message, $code = 0, Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+
+    public function __toString()
+    {
+        return __CLASS__ . ": [{$this->code}]: {$this->message}\n";
+    }
+}


### PR DESCRIPTION
## What

- adds error param validation
- throw custom OAuthException if an error is found
- update README to describe error handling
- makes the Connection ID available in the tenant data, which is required to delete a connection (disconnect a tenant) (related to #65)

## Why

- the app we were building needed to gracefully handle the case where a user clicks Cancel on the Xero Authorisation page
- without this change, the callback controller redirects back to Xero, which generates a 500 error

