### PR TITLE
[Docs] - Fix OAuthException handling example in Laravel 8-10

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ return Application::configure(basePath: dirname(__DIR__))
 
 #### Laravel 8-10
 
-Use the `reportable` method in the `App\Exceptions\Handler` class:
+Use the `renderable` method in the `App\Exceptions\Handler` class:
 
 ```php
     public function register()

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Use the `reportable` method in the `App\Exceptions\Handler` class:
 ```php
     public function register()
     {
-        $this->reportable(function (OAuthException $e) {
+        $this->renderable(function (OAuthException $e) {
             // Handle when the user clicks cancel on the Xero authorization screen
             return redirect('/my/xero/connect/page')->with('errorMessage', $e->getMessage());
         });


### PR DESCRIPTION
The current documentation provides a wrong example for handling the `OAuthException` for Laravel 8-10.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Enhanced the `README.md` with detailed installation, configuration, error handling, credential storage, and webhook usage sections.
	- Provided specific instructions for handling exceptions in Laravel versions 8-11.
	- Introduced guidance on creating and managing webhooks with Xero.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->