### PR TITLE
id_token is string

### DIFF
--- a/src/Events/XeroAuthorized.php
+++ b/src/Events/XeroAuthorized.php
@@ -6,7 +6,7 @@ class XeroAuthorized
 {
     public string $token;
     public string $refresh_token;
-    public array $id_token;
+    public string $id_token;
     public string $expires;
     public array $tenants;
 

--- a/tests/Feature/Routes/CallbackTest.php
+++ b/tests/Feature/Routes/CallbackTest.php
@@ -62,7 +62,7 @@ class CallbackTest extends TestCase
         Event::assertDispatched(XeroAuthorized::class, function (XeroAuthorized $event) {
             $this->assertEquals('token', $event->token);
             $this->assertEquals('refresh-token', $event->refresh_token);
-            $this->assertEquals(['token' => 'foo'], $event->id_token);
+            $this->assertEquals('foo', $event->id_token);
             $this->assertEquals('1234', $event->expires);
             $this->assertEquals([
                 [

--- a/tests/TestSupport/Mocks/MockAccessToken.php
+++ b/tests/TestSupport/Mocks/MockAccessToken.php
@@ -40,9 +40,7 @@ class MockAccessToken implements AccessTokenInterface, Arrayable
     public function getValues()
     {
         return [
-            'id_token' => [
-                'token' => 'foo',
-            ],
+            'id_token' => 'foo'
         ];
     }
 

--- a/tests/Unit/CredentialManagersTest.php
+++ b/tests/Unit/CredentialManagersTest.php
@@ -63,9 +63,7 @@ class CredentialManagersTest extends TestCase
         $createExistingData($sut, $existingData = [
             'token' => 'default-token',
             'refresh_token' => 'default-refresh-token',
-            'id_token' => [
-                'token' => 'foo',
-            ],
+            'id_token' => 'foo',
             'expires' => $expires = strtotime('+1 hour'),
             'tenants' => [
                 [
@@ -126,9 +124,7 @@ class CredentialManagersTest extends TestCase
         $this->assertEquals([
             'token' => 'token',
             'refresh_token' => 'refresh-token',
-            'id_token' => [
-                'token' => 'foo',
-            ],
+            'id_token' => 'foo',
             'expires' => '1234',
             'tenants' => [
                 'tenant' => 'tenant_id',
@@ -161,9 +157,7 @@ class CredentialManagersTest extends TestCase
         $this->assertEquals([
             'token' => 'token',
             'refresh_token' => 'refresh-token',
-            'id_token' => [
-                'token' => 'foo',
-            ],
+            'id_token' => 'foo',
             'expires' => '1234',
             'tenants' => null,
         ], $sut->getData());


### PR DESCRIPTION
Hi Webfox team 👋 

This PR is perhaps more of a question than a hard proposal because I'm confused how it works in its current state, leading me to assume I'm doing something very wrong actually using the library.

With the `id_token` instance variable defined as an array I get the error on the Xero authorization callback.

```
Cannot assign string to property Webfox\Xero\Events\XeroAuthorized::$id_token of type array
```

If I inspect the data fed into the `XeroAuthorized` event (from `$oauth->getData()`) the `id_token` is in fact a string; and looking at the [OauthCredentialManager.php](https://github.com/webfox/laravel-xero-oauth2/blob/master/src/OauthCredentialManager.php) it seems to be treated as a string throughout.

I am currently using the FileStore; the CacheStore is consistent.

* My config: https://gist.github.com/afoster/b7cc0baa634a7c492ce3ba78b8aeafbe
* My controller: https://gist.github.com/afoster/a3a9fb339abab6755209c42b6cae4e33

Any suggestions welcome. Thanks